### PR TITLE
Persist table sort order during row selection

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -295,7 +295,9 @@ builder_server <- function(id) {
                                     select(values$bib_table_col),
                                  selection = list(mode ="single"),
                                  options = list(dom = "t",
-                                                pageLength = 10000),
+                                                pageLength = 10000,
+                                                stateSave = TRUE,
+                                                stateDuration = 0),
                                  rownames = FALSE, server = FALSE)
       }
 

--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -240,6 +240,8 @@ viewer_server <- function(id) {
                                  selection = "single",
                                  options = list(dom = "t",
                                                 pageLength = 10000,
+                                                stateSave = TRUE,
+                                                stateDuration = 0,
                                                 #autoWidth = TRUE,
                                                 columnDefs =
                                                   list(list(width =
@@ -368,6 +370,8 @@ viewer_server <- function(id) {
                                selection = "single",
                                options = list(dom = "t",
                                               pageLength = 10000,
+                                              stateSave = TRUE,
+                                              stateDuration = 0,
                                               #autoWidth = TRUE,
                                               columnDefs =
                                                 list(list(width =
@@ -886,6 +890,8 @@ viewer_server <- function(id) {
                                        callback = JS(newjs),
                                        options = list(dom = "t",
                                                       pageLength = 10000,
+                                                      stateSave = TRUE,
+                                                      stateDuration = 0,
                                                       #autoWidth = TRUE,
                                                       columnDefs =
                                                         list(list(width =


### PR DESCRIPTION
This change addresses an issue where sorting the bibliography table by the "extra" column (or any other column) would be lost when a row was selected. This happened because row selection triggered a reactive update that re-rendered the DataTable widget, causing it to revert to its default sort order.

By enabling the `stateSave` option in the `DataTables` configuration, the table's state (including sorting, pagination, and search) is now preserved across these re-renders. `stateDuration = 0` was also added to follow best practices for session-based state persistence.

The changes were applied to:
- The main bibliography table in `R/builder_server.R`.
- The main bibliography table and the summary table in `R/viewer_server.R`.

---
*PR created automatically by Jules for task [3591493824590594355](https://jules.google.com/task/3591493824590594355) started by @pmcelhany*