### PR TITLE
fix: ensure table sort order persists during row selection and data u…

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -295,8 +295,11 @@ builder_server <- function(id) {
                                     select(values$bib_table_col),
                                  selection = list(mode ="single"),
                                  options = list(dom = "t",
-                                                pageLength = 10000),
-                                 rownames = FALSE, server = FALSE)
+                                                pageLength = 10000,
+                                                stateSave = TRUE,
+                                                stateDuration = 0,
+                                                order = list()),
+                                 rownames = FALSE, server = TRUE)
       }
 
       ### Show selected paper info -------------------------------------

--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -240,12 +240,15 @@ viewer_server <- function(id) {
                                  selection = "single",
                                  options = list(dom = "t",
                                                 pageLength = 10000,
+                                                stateSave = TRUE,
+                                                stateDuration = 0,
+                                                order = list(),
                                                 #autoWidth = TRUE,
                                                 columnDefs =
                                                   list(list(width =
                                                               '200px',
                                                             targets = "_all"))),
-                                 rownames = FALSE, server = FALSE)
+                                 rownames = FALSE, server = TRUE)
 
         ### Full  table -----------------------------------------
         output$table_full <- DT::renderDataTable(values$d_mcdr_tagged %>%
@@ -256,13 +259,16 @@ viewer_server <- function(id) {
                                              options =
                                                list(dom = "t",
                                                     pageLength = 10000,
+                                                    stateSave = TRUE,
+                                                    stateDuration = 0,
+                                                    order = list(),
                                                     #autoWidth = TRUE
                                                     list(width =
                                                            '20px',
                                                          targets = "_all"),
                                                     scrollX = TRUE,
                                                     scrollY = TRUE),
-                                             rownames = FALSE, server = FALSE)
+                                             rownames = FALSE, server = TRUE)
 
         ### Plot x variables dropdown -----------------
 
@@ -368,12 +374,15 @@ viewer_server <- function(id) {
                                selection = "single",
                                options = list(dom = "t",
                                               pageLength = 10000,
+                                              stateSave = TRUE,
+                                              stateDuration = 0,
+                                              order = list(),
                                               #autoWidth = TRUE,
                                               columnDefs =
                                                 list(list(width =
                                                             '200px',
                                                           targets = "_all"))),
-                               rownames = FALSE, server = FALSE)
+                               rownames = FALSE, server = TRUE)
     })
 
     ## Download database, tag cat, and ris file --------------
@@ -886,6 +895,9 @@ viewer_server <- function(id) {
                                        callback = JS(newjs),
                                        options = list(dom = "t",
                                                       pageLength = 10000,
+                                                      stateSave = TRUE,
+                                                      stateDuration = 0,
+                                                      order = list(),
                                                       #autoWidth = TRUE,
                                                       columnDefs =
                                                         list(list(width =
@@ -894,7 +906,7 @@ viewer_server <- function(id) {
                                                       scrollX = TRUE,
                                                       scrollY = TRUE,
                                                       colReorder = TRUE),
-                                       rownames = FALSE, server = FALSE,
+                                       rownames = FALSE, server = TRUE,
       )
 
 


### PR DESCRIPTION
…pdates

- Enable `stateSave` and set `stateDuration = 0` for all bibliography tables.
- Add `order = list()` to prevent default sorting from overriding saved state.
- Set `server = TRUE` to improve robust state persistence during reactive updates (e.g., when saving edits).
- Applied changes to builder bibliography table, viewer bibliography table (including toggled 'extra' view), full bibliography table, and summary table.