### PR TITLE
fix: robustly persist table sort order during all interactions

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -130,12 +130,32 @@ builder_server <- function(id) {
                            last_key = NULL, inspire_quotes = NULL,
                            inspire_images = NULL, d_content_db = NULL,
                            d_old_key_db = NULL, d_split_db = NULL,
-                           tag_variables = NULL, bib_table_col = NULL,
+                           tag_variables = NULL,
+                           bib_table_col = c("first_author", "publication_year", "title"),
                            active_cat_tabs = character(0),
-                           active_tag_ui = character(0))
+                           active_tag_ui = character(0),
+                           table_trigger = 0)
 
     ## Proxy for the papers table ------------------------------
     dt_proxy <- DT::dataTableProxy("table")
+
+    ### Bibliography table -----------------------------------------
+    output$table <- renderDT({
+      # trigger update when data is initially loaded or filtered or when show_extra changes
+      values$table_trigger
+      req(values$d_mcdr_filtered)
+      req(all(values$bib_table_col %in% names(values$d_mcdr_filtered)))
+
+      isolate(values$d_mcdr_filtered) %>%
+        select(all_of(values$bib_table_col))
+    },
+    selection = list(mode = "single"),
+    options = list(dom = "t",
+                   pageLength = 10000,
+                   stateSave = TRUE,
+                   stateDuration = 0,
+                   order = list()),
+    rownames = FALSE, server = TRUE)
 
   ## Render paper info function ----------------------------
   render_paper_info <- function(label, paper_var){
@@ -245,6 +265,7 @@ builder_server <- function(id) {
 
       ### Filter database --------
       # the d_mcdr_filtered dataframe is the filtered data shown in table
+      values$table_trigger <- values$table_trigger + 1
       values$d_mcdr_filtered <- values$d_mcdr_tagged %>%
          filter(if(input$exclude_obsolete &
                   "date_time_obsolete_db" %in% names(.))
@@ -288,16 +309,6 @@ builder_server <- function(id) {
       # values$active_tag_ui <-
       #   values$tag_variables[!(values$tag_variables %in% notes_variables)]
 
-      ### Bibliography table -----------------------------------------
-      if(all(values$bib_table_col %in%
-             names(values$d_mcdr_filtered))){
-        output$table <- renderDT(values$d_mcdr_filtered %>%
-                                    select(values$bib_table_col),
-                                 selection = list(mode ="single"),
-                                 options = list(dom = "t",
-                                                pageLength = 10000),
-                                 rownames = FALSE, server = FALSE)
-      }
 
       ### Show selected paper info -------------------------------------
       output$selected_year <- render_paper_info("Year:", "publication_year")
@@ -356,6 +367,8 @@ builder_server <- function(id) {
       values$bib_table_col <- c("first_author", "publication_year", "title")
       output$selected_extra <- NULL
     }
+    # trigger table update as the column structure has changed
+    values$table_trigger <- values$table_trigger + 1
   })
 
   ## Observe select filter fields  -------------------------------
@@ -398,12 +411,22 @@ builder_server <- function(id) {
     input$filter_var %>%
         map(\(x) filter_fun(x))
 
+    # surgically update the data without re-rendering the whole widget
+    replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                  select(all_of(values$bib_table_col)),
+                resetPaging = FALSE, rownames = FALSE)
+
   })
 
   ## Observe show all button  -------------------------
 
   observeEvent(input$show_all_db, {
     values$d_mcdr_filtered <-  values$d_mcdr_tagged
+
+    # surgically update the data without re-rendering the whole widget
+    replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                  select(all_of(values$bib_table_col)),
+                resetPaging = FALSE, rownames = FALSE)
   })
 
   ## Observe unselect filters button ------------------------
@@ -458,6 +481,11 @@ builder_server <- function(id) {
       values$d_mcdr_filtered[values$d_mcdr_filtered$key == key,] <-
         values$d_mcdr_tagged[values$d_mcdr_tagged$key == key, ]
 
+      # Use replaceData to surgically update the table content without re-rendering the whole widget.
+      # This preserves the user's current sort order and pagination.
+      replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                    select(all_of(values$bib_table_col)),
+                  resetPaging = FALSE, rownames = FALSE)
     }
   }
 

--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -119,7 +119,41 @@ viewer_server <- function(id) {
                              categories = NULL,
                              tag_variables = NULL,
                              d_category_meta = NULL, d_mcdr_filtered = NULL,
-                             d_plot = NULL)
+                             d_plot = NULL,
+                             table_trigger = 0)
+
+    dt_proxy <- DT::dataTableProxy("table")
+    dt_summary_proxy <- DT::dataTableProxy("summary_table")
+
+    # trigger table re-render when columns change
+    observeEvent(input$show_extra, {
+      values$table_trigger <- values$table_trigger + 1
+    })
+
+    ### Table variables -----------------------------------------
+    table_vars <- reactive({
+      vars <- c("author", "publication_year", "title")
+      if (!is.null(input$show_extra) && input$show_extra) {
+        vars <- c("author", "publication_year", "title", "extra")
+      }
+      return(vars)
+    })
+
+    ### Bibliography table -----------------------------------------
+    output$table <- renderDT({
+      values$table_trigger
+      req(values$d_mcdr_filtered)
+      isolate(values$d_mcdr_filtered) %>%
+        select(all_of(table_vars()))
+    },
+    selection = "single",
+    options = list(dom = "t",
+                   pageLength = 10000,
+                   stateSave = TRUE,
+                   stateDuration = 0,
+                   order = list(),
+                   columnDefs = list(list(width = '200px', targets = "_all"))),
+    rownames = FALSE, server = TRUE)
 
     ## render database chooser
     output$db_chooser <- renderUI({
@@ -194,6 +228,7 @@ viewer_server <- function(id) {
           return(a)
         }
 
+
         values$d_mcdr_tagged <-  read_csv(database_file_path) %>%
            mutate(across(everything(), as.character)) %>%
           remove_empty(which = "rows") %>%
@@ -230,39 +265,22 @@ viewer_server <- function(id) {
         incProgress(3/4)
 
 
-        table_vars <- c("author", "publication_year", "title")
-        if(input$show_extra){
-          table_vars <- c("author", "publication_year", "title", "extra")
-        }
-        ### Filter  table -----------------------------------------
-        output$table <- renderDT(values$d_mcdr_filtered %>%
-                                    select(table_vars),
-                                 selection = "single",
-                                 options = list(dom = "t",
-                                                pageLength = 10000,
-                                                #autoWidth = TRUE,
-                                                columnDefs =
-                                                  list(list(width =
-                                                              '200px',
-                                                            targets = "_all"))),
-                                 rownames = FALSE, server = FALSE)
-
         ### Full  table -----------------------------------------
-        output$table_full <- DT::renderDataTable(values$d_mcdr_tagged %>%
-                                                   select(author,
-                                                          publication_year,
-                                                          title),
-                                             selection = "none",
-                                             options =
-                                               list(dom = "t",
-                                                    pageLength = 10000,
-                                                    #autoWidth = TRUE
-                                                    list(width =
-                                                           '20px',
-                                                         targets = "_all"),
-                                                    scrollX = TRUE,
-                                                    scrollY = TRUE),
-                                             rownames = FALSE, server = FALSE)
+        output$table_full <- DT::renderDataTable({
+          req(values$d_mcdr_tagged)
+          values$d_mcdr_tagged %>%
+            select(author, publication_year, title)
+        },
+        selection = "none",
+        options = list(dom = "t",
+                       pageLength = 10000,
+                       stateSave = TRUE,
+                       stateDuration = 0,
+                       order = list(),
+                       list(width = '20px', targets = "_all"),
+                       scrollX = TRUE,
+                       scrollY = TRUE),
+        rownames = FALSE, server = TRUE)
 
         ### Plot x variables dropdown -----------------
 
@@ -351,30 +369,11 @@ viewer_server <- function(id) {
 
 
         incProgress(4/4)
+        values$table_trigger <- values$table_trigger + 1
       })
       }
     })
 
-    ## Observe show extra -------------------
-    observeEvent(input$show_extra,{
-      if(input$show_extra){
-        table_vars <- c("author", "publication_year", "title", "extra")
-      } else{
-        table_vars <- c("author", "publication_year", "title")
-      }
-      ### Filter  table -----------------------------------------
-      output$table <- renderDT(values$d_mcdr_filtered %>%
-                                 select(table_vars),
-                               selection = "single",
-                               options = list(dom = "t",
-                                              pageLength = 10000,
-                                              #autoWidth = TRUE,
-                                              columnDefs =
-                                                list(list(width =
-                                                            '200px',
-                                                          targets = "_all"))),
-                               rownames = FALSE, server = FALSE)
-    })
 
     ## Download database, tag cat, and ris file --------------
     output$download_db <- downloadHandler(
@@ -582,6 +581,11 @@ viewer_server <- function(id) {
       }
 
       values$d_mcdr_filtered <- d_filtered
+
+      # surgically update the data without re-rendering the whole widget
+      replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                    select(all_of(table_vars())),
+                  resetPaging = FALSE, rownames = FALSE)
 
       ### render filter summary ----------------------------
       output$n_papers_selected <- renderText(paste("Number of papers selected:",
@@ -881,22 +885,26 @@ viewer_server <- function(id) {
            select(input$summary_var)
       }
 
-      output$summary_table <- renderDT(d, selection = "none",
-                                       extensions = 'ColReorder',
-                                       callback = JS(newjs),
-                                       options = list(dom = "t",
-                                                      pageLength = 10000,
-                                                      #autoWidth = TRUE,
-                                                      columnDefs =
-                                                        list(list(width =
-                                                                    '200px',
-                                                                  targets = "_all")),
-                                                      scrollX = TRUE,
-                                                      scrollY = TRUE,
-                                                      colReorder = TRUE),
-                                       rownames = FALSE, server = FALSE,
-      )
+      output$summary_table <- renderDT({
+        req(d)
+        isolate(d)
+      },
+      selection = "none",
+      extensions = 'ColReorder',
+      callback = JS(newjs),
+      options = list(dom = "t",
+                     pageLength = 10000,
+                     stateSave = TRUE,
+                     stateDuration = 0,
+                     order = list(),
+                     columnDefs = list(list(width = '200px', targets = "_all")),
+                     scrollX = TRUE,
+                     scrollY = TRUE,
+                     colReorder = TRUE),
+      rownames = FALSE, server = TRUE)
 
+      replaceData(dt_summary_proxy, d, resetPaging = FALSE,
+                  rownames = FALSE)
 
     }, ignoreInit = TRUE)
 


### PR DESCRIPTION
Refactored table rendering to use `DT` proxies and state preservation. This ensures that user-selected sorting (e.g., by the "extra" field) is maintained even after selecting rows, saving edits, or updating filters.

Key Technical Changes:
- Enabled `stateSave = TRUE`, `stateDuration = 0`, and `order = list()` to utilize browser session storage for UI state.
- Moved `renderDT` calls to the top level of server functions and isolated the data dependencies to prevent widget destruction during reactive updates.
- Implemented `DT::replaceData()` via proxies for surgical data updates that natively preserve sorting and pagination.
- Added a `table_trigger` reactive value to handle full re-renders cleanly when column structures change (e.g., toggling "extra" field).
- Set `server = TRUE` for robust proxy support.

Affected components:
- Builder module main bibliography table.
- Viewer module main bibliography table, full database table, and summary table.