### PR TITLE
fix: ensure table sort order and selected row visibility persist

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -130,12 +130,42 @@ builder_server <- function(id) {
                            last_key = NULL, inspire_quotes = NULL,
                            inspire_images = NULL, d_content_db = NULL,
                            d_old_key_db = NULL, d_split_db = NULL,
-                           tag_variables = NULL, bib_table_col = NULL,
+                           tag_variables = NULL,
+                           bib_table_col = c("first_author", "publication_year", "title"),
                            active_cat_tabs = character(0),
-                           active_tag_ui = character(0))
+                           active_tag_ui = character(0),
+                           table_trigger = 0)
 
     ## Proxy for the papers table ------------------------------
     dt_proxy <- DT::dataTableProxy("table")
+
+    ### Bibliography table -----------------------------------------
+    output$table <- renderDT({
+      # trigger update when data is initially loaded or filtered or when show_extra changes
+      values$table_trigger
+      req(values$d_mcdr_filtered)
+      req(all(values$bib_table_col %in% names(values$d_mcdr_filtered)))
+
+      isolate(values$d_mcdr_filtered) %>%
+        select(all_of(values$bib_table_col))
+    },
+    selection = list(mode = "single"),
+    options = list(dom = "t",
+                   pageLength = 10000,
+                   stateSave = TRUE,
+                   stateDuration = 0,
+                   order = list(),
+                   scrollY = "600px",
+                   scrollCollapse = TRUE,
+                   drawCallback = JS("function(settings) {
+                     var table = this.api();
+                     var row = table.row('.selected');
+                     if (row.node()) {
+                       row.node().scrollIntoView({ block: 'nearest' });
+                     }
+                   }"),
+                   columnDefs = list(list(visible = FALSE, targets = 0))),
+    rownames = TRUE, server = TRUE)
 
   ## Render paper info function ----------------------------
   render_paper_info <- function(label, paper_var){
@@ -245,6 +275,7 @@ builder_server <- function(id) {
 
       ### Filter database --------
       # the d_mcdr_filtered dataframe is the filtered data shown in table
+      values$table_trigger <- values$table_trigger + 1
       values$d_mcdr_filtered <- values$d_mcdr_tagged %>%
          filter(if(input$exclude_obsolete &
                   "date_time_obsolete_db" %in% names(.))
@@ -288,16 +319,6 @@ builder_server <- function(id) {
       # values$active_tag_ui <-
       #   values$tag_variables[!(values$tag_variables %in% notes_variables)]
 
-      ### Bibliography table -----------------------------------------
-      if(all(values$bib_table_col %in%
-             names(values$d_mcdr_filtered))){
-        output$table <- renderDT(values$d_mcdr_filtered %>%
-                                    select(values$bib_table_col),
-                                 selection = list(mode ="single"),
-                                 options = list(dom = "t",
-                                                pageLength = 10000),
-                                 rownames = FALSE, server = FALSE)
-      }
 
       ### Show selected paper info -------------------------------------
       output$selected_year <- render_paper_info("Year:", "publication_year")
@@ -356,6 +377,8 @@ builder_server <- function(id) {
       values$bib_table_col <- c("first_author", "publication_year", "title")
       output$selected_extra <- NULL
     }
+    # trigger table update as the column structure has changed
+    values$table_trigger <- values$table_trigger + 1
   })
 
   ## Observe select filter fields  -------------------------------
@@ -398,12 +421,22 @@ builder_server <- function(id) {
     input$filter_var %>%
         map(\(x) filter_fun(x))
 
+    # surgically update the data without re-rendering the whole widget
+    replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                  select(all_of(values$bib_table_col)),
+                resetPaging = FALSE, rownames = TRUE)
+
   })
 
   ## Observe show all button  -------------------------
 
   observeEvent(input$show_all_db, {
     values$d_mcdr_filtered <-  values$d_mcdr_tagged
+
+    # surgically update the data without re-rendering the whole widget
+    replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                  select(all_of(values$bib_table_col)),
+                resetPaging = FALSE, rownames = TRUE)
   })
 
   ## Observe unselect filters button ------------------------
@@ -458,6 +491,11 @@ builder_server <- function(id) {
       values$d_mcdr_filtered[values$d_mcdr_filtered$key == key,] <-
         values$d_mcdr_tagged[values$d_mcdr_tagged$key == key, ]
 
+      # Use replaceData to surgically update the table content without re-rendering the whole widget.
+      # This preserves the user's current sort order and pagination.
+      replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                    select(all_of(values$bib_table_col)),
+                  resetPaging = FALSE, rownames = TRUE)
     }
   }
 

--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -119,7 +119,51 @@ viewer_server <- function(id) {
                              categories = NULL,
                              tag_variables = NULL,
                              d_category_meta = NULL, d_mcdr_filtered = NULL,
-                             d_plot = NULL)
+                             d_plot = NULL,
+                             table_trigger = 0)
+
+    dt_proxy <- DT::dataTableProxy("table")
+    dt_summary_proxy <- DT::dataTableProxy("summary_table")
+
+    # trigger table re-render when columns change
+    observeEvent(input$show_extra, {
+      values$table_trigger <- values$table_trigger + 1
+    })
+
+    ### Table variables -----------------------------------------
+    table_vars <- reactive({
+      vars <- c("author", "publication_year", "title")
+      if (!is.null(input$show_extra) && input$show_extra) {
+        vars <- c("author", "publication_year", "title", "extra")
+      }
+      return(vars)
+    })
+
+    ### Bibliography table -----------------------------------------
+    output$table <- renderDT({
+      values$table_trigger
+      req(values$d_mcdr_filtered)
+      isolate(values$d_mcdr_filtered) %>%
+        select(all_of(table_vars()))
+    },
+    selection = "single",
+    options = list(dom = "t",
+                   pageLength = 10000,
+                   stateSave = TRUE,
+                   stateDuration = 0,
+                   order = list(),
+                   scrollY = "600px",
+                   scrollCollapse = TRUE,
+                   drawCallback = JS("function(settings) {
+                     var table = this.api();
+                     var row = table.row('.selected');
+                     if (row.node()) {
+                       row.node().scrollIntoView({ block: 'nearest' });
+                     }
+                   }"),
+                   columnDefs = list(list(visible = FALSE, targets = 0),
+                                     list(width = '200px', targets = "_all"))),
+    rownames = TRUE, server = TRUE)
 
     ## render database chooser
     output$db_chooser <- renderUI({
@@ -194,6 +238,7 @@ viewer_server <- function(id) {
           return(a)
         }
 
+
         values$d_mcdr_tagged <-  read_csv(database_file_path) %>%
            mutate(across(everything(), as.character)) %>%
           remove_empty(which = "rows") %>%
@@ -230,39 +275,23 @@ viewer_server <- function(id) {
         incProgress(3/4)
 
 
-        table_vars <- c("author", "publication_year", "title")
-        if(input$show_extra){
-          table_vars <- c("author", "publication_year", "title", "extra")
-        }
-        ### Filter  table -----------------------------------------
-        output$table <- renderDT(values$d_mcdr_filtered %>%
-                                    select(table_vars),
-                                 selection = "single",
-                                 options = list(dom = "t",
-                                                pageLength = 10000,
-                                                #autoWidth = TRUE,
-                                                columnDefs =
-                                                  list(list(width =
-                                                              '200px',
-                                                            targets = "_all"))),
-                                 rownames = FALSE, server = FALSE)
-
         ### Full  table -----------------------------------------
-        output$table_full <- DT::renderDataTable(values$d_mcdr_tagged %>%
-                                                   select(author,
-                                                          publication_year,
-                                                          title),
-                                             selection = "none",
-                                             options =
-                                               list(dom = "t",
-                                                    pageLength = 10000,
-                                                    #autoWidth = TRUE
-                                                    list(width =
-                                                           '20px',
-                                                         targets = "_all"),
-                                                    scrollX = TRUE,
-                                                    scrollY = TRUE),
-                                             rownames = FALSE, server = FALSE)
+        output$table_full <- DT::renderDataTable({
+          req(values$d_mcdr_tagged)
+          values$d_mcdr_tagged %>%
+            select(author, publication_year, title)
+        },
+        selection = "none",
+        options = list(dom = "t",
+                       pageLength = 10000,
+                       stateSave = TRUE,
+                       stateDuration = 0,
+                       order = list(),
+                       columnDefs = list(list(visible = FALSE, targets = 0),
+                                         list(width = '20px', targets = "_all")),
+                       scrollX = TRUE,
+                       scrollY = TRUE),
+        rownames = TRUE, server = TRUE)
 
         ### Plot x variables dropdown -----------------
 
@@ -351,30 +380,11 @@ viewer_server <- function(id) {
 
 
         incProgress(4/4)
+        values$table_trigger <- values$table_trigger + 1
       })
       }
     })
 
-    ## Observe show extra -------------------
-    observeEvent(input$show_extra,{
-      if(input$show_extra){
-        table_vars <- c("author", "publication_year", "title", "extra")
-      } else{
-        table_vars <- c("author", "publication_year", "title")
-      }
-      ### Filter  table -----------------------------------------
-      output$table <- renderDT(values$d_mcdr_filtered %>%
-                                 select(table_vars),
-                               selection = "single",
-                               options = list(dom = "t",
-                                              pageLength = 10000,
-                                              #autoWidth = TRUE,
-                                              columnDefs =
-                                                list(list(width =
-                                                            '200px',
-                                                          targets = "_all"))),
-                               rownames = FALSE, server = FALSE)
-    })
 
     ## Download database, tag cat, and ris file --------------
     output$download_db <- downloadHandler(
@@ -582,6 +592,11 @@ viewer_server <- function(id) {
       }
 
       values$d_mcdr_filtered <- d_filtered
+
+      # surgically update the data without re-rendering the whole widget
+      replaceData(dt_proxy, values$d_mcdr_filtered %>%
+                    select(all_of(table_vars())),
+                  resetPaging = FALSE, rownames = TRUE)
 
       ### render filter summary ----------------------------
       output$n_papers_selected <- renderText(paste("Number of papers selected:",
@@ -881,22 +896,27 @@ viewer_server <- function(id) {
            select(input$summary_var)
       }
 
-      output$summary_table <- renderDT(d, selection = "none",
-                                       extensions = 'ColReorder',
-                                       callback = JS(newjs),
-                                       options = list(dom = "t",
-                                                      pageLength = 10000,
-                                                      #autoWidth = TRUE,
-                                                      columnDefs =
-                                                        list(list(width =
-                                                                    '200px',
-                                                                  targets = "_all")),
-                                                      scrollX = TRUE,
-                                                      scrollY = TRUE,
-                                                      colReorder = TRUE),
-                                       rownames = FALSE, server = FALSE,
-      )
+      output$summary_table <- renderDT({
+        req(d)
+        isolate(d)
+      },
+      selection = "none",
+      extensions = 'ColReorder',
+      callback = JS(newjs),
+      options = list(dom = "t",
+                     pageLength = 10000,
+                     stateSave = TRUE,
+                     stateDuration = 0,
+                     order = list(),
+                     columnDefs = list(list(visible = FALSE, targets = 0),
+                                       list(width = '200px', targets = "_all")),
+                     scrollX = TRUE,
+                     scrollY = TRUE,
+                     colReorder = TRUE),
+      rownames = TRUE, server = TRUE)
 
+      replaceData(dt_summary_proxy, d, resetPaging = FALSE,
+                  rownames = TRUE)
 
     }, ignoreInit = TRUE)
 


### PR DESCRIPTION
Refactored bibliography table rendering to use `DT` proxies, state preservation, and automatic scrolling. This ensures a seamless experience where sorting, pagination, and the selected row's visibility are maintained during data updates (like saving edits or filtering).

Key Technical Changes:
- Enabled `stateSave = TRUE` and `stateDuration = 0` to persist UI state.
- Set `server = TRUE` and `rownames = TRUE` (hidden) to ensure robust and reliable row selection mapping even when the table is sorted.
- Implemented `DT::replaceData()` for surgical content updates that natively preserve sort order and pagination.
- Added a JavaScript `drawCallback` with `scrollIntoView()` to keep the currently selected row visible in the viewport after updates.
- Refactored `renderDT` calls to the top level of server modules for a more stable and performant Shiny architecture.
- Added `order = list()` to prevent default sort overrides during initialization.

Affected components:
- Builder module main bibliography table.
- Viewer module main bibliography table, full database table, and summary table.