### PR TITLE
fix: ensure builder table sort order persists and selection is centered

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -295,7 +295,19 @@ builder_server <- function(id) {
                                     select(values$bib_table_col),
                                  selection = list(mode ="single"),
                                  options = list(dom = "t",
-                                                pageLength = 10000),
+                                                pageLength = 10000,
+                                                stateSave = TRUE,
+                                                stateDuration = 0,
+                                                order = list(),
+                                                scrollY = "600px",
+                                                scrollCollapse = TRUE,
+                                                drawCallback = JS("function(settings) {
+                                                  var table = this.api();
+                                                  var row = table.row('.selected');
+                                                  if (row.node()) {
+                                                    row.node().scrollIntoView({ block: 'center', behavior: 'instant' });
+                                                  }
+                                                }")),
                                  rownames = FALSE, server = FALSE)
       }
 


### PR DESCRIPTION
Enhanced the builder bibliography table with `DT` persistence and centering logic. This ensures that user-selected sorting (e.g., by "Extra") is maintained and the selected row remains centered in the viewport after saving edits or other updates.

Key Technical Changes:
- Enabled `stateSave = TRUE` and `stateDuration = 0` to persist sort and pagination settings in the browser session.
- Added `order = list()` to prevent DataTables from applying its default initial sort, allowing saved state to prevail.
- Included `scrollY = "600px"` and `scrollCollapse = TRUE` to provide a stable, scrollable table body.
- Added a `drawCallback` JavaScript function to automatically center the currently selected row using `scrollIntoView({ block: 'center' })`.
- Maintained `server = FALSE` and `rownames = FALSE` to ensure perfect compatibility with DataTables' state saving and to avoid JSON response errors.

This change is strictly applied to the Builder module as requested.