### PR TITLE
fix: definitive fix for builder table sort and scroll persistence

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -295,7 +295,19 @@ builder_server <- function(id) {
                                     select(values$bib_table_col),
                                  selection = list(mode ="single"),
                                  options = list(dom = "t",
-                                                pageLength = 10000),
+                                                pageLength = 10000,
+                                                stateSave = TRUE,
+                                                stateDuration = 0,
+                                                order = list(),
+                                                scrollY = "600px",
+                                                scrollCollapse = TRUE,
+                                                drawCallback = JS("function(settings) {
+                                                  var table = this.api();
+                                                  var row = table.row('.selected');
+                                                  if (row.node()) {
+                                                    row.node().scrollIntoView({ block: 'center', behavior: 'instant' });
+                                                  }
+                                                }")),
                                  rownames = FALSE, server = FALSE)
       }
 


### PR DESCRIPTION
Enhanced the builder bibliography table with robust state preservation and centering logic while maintaining the stable client-side processing mode. This ensures that user-selected sorting is maintained and the selected row remains centered in the viewport after saving edits or other updates, without encountering JSON response errors.

Key Technical Changes:
- Enabled `stateSave = TRUE` and `stateDuration = 0` to utilize browser session storage for UI state.
- Added `order = list()` to prevent DataTables from applying its default initial sort, allowing the saved state to prevail correctly.
- Included `scrollY = "600px"` and `scrollCollapse = TRUE` to provide a stable, scrollable table viewport.
- Added a `drawCallback` JavaScript function that automatically centers the currently selected row using `scrollIntoView({ block: "center" })`.
- Maintained `server = FALSE` and `rownames = FALSE` for the main bibliography table and all check tables to ensure perfect stability and completely avoid the "Invalid JSON response" errors.

This change is strictly applied to the Builder module as requested. No changes were made to the Viewer module.