### PR TITLE
Fix bibliography table sorting persistence and selection centering

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -130,12 +130,46 @@ builder_server <- function(id) {
                            last_key = NULL, inspire_quotes = NULL,
                            inspire_images = NULL, d_content_db = NULL,
                            d_old_key_db = NULL, d_split_db = NULL,
-                           tag_variables = NULL, bib_table_col = NULL,
+                           tag_variables = NULL,
+                           bib_table_col = c("first_author", "publication_year", "title"),
                            active_cat_tabs = character(0),
-                           active_tag_ui = character(0))
+                           active_tag_ui = character(0),
+                           table_trigger = 0)
 
     ## Proxy for the papers table ------------------------------
     dt_proxy <- DT::dataTableProxy("table")
+
+    ### Bibliography table -----------------------------------------
+    output$table <- renderDT({
+      # trigger update when data is initially loaded or filtered or when show_extra changes
+      values$table_trigger
+      req(values$d_mcdr_filtered)
+      req(all(values$bib_table_col %in% names(values$d_mcdr_filtered)))
+
+      isolate(values$d_mcdr_filtered) %>%
+        select(all_of(values$bib_table_col))
+    },
+    selection = list(mode = "single"),
+    callback = JS("
+      table.on('select', function(e, dt, type, indexes) {
+        if (type === 'row') {
+          var row = table.row(indexes).node();
+          if (row) {
+            setTimeout(function() {
+              row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            }, 100);
+          }
+        }
+      });
+    "),
+    options = list(dom = "t",
+                   pageLength = 10000,
+                   stateSave = TRUE,
+                   stateDuration = 0,
+                   order = list(),
+                   scrollY = "600px",
+                   scrollCollapse = TRUE),
+    rownames = FALSE, server = FALSE)
 
   ## Render paper info function ----------------------------
   render_paper_info <- function(label, paper_var){
@@ -251,6 +285,9 @@ builder_server <- function(id) {
           (is.na(date_time_obsolete_db) | date_time_obsolete_db == "NA") else
             TRUE)
 
+      # trigger table render on initial load
+      values$table_trigger <- values$table_trigger + 1
+
       incProgress(3/4)
 
       ### Add notes input to ui  ------------------------------------
@@ -288,16 +325,6 @@ builder_server <- function(id) {
       # values$active_tag_ui <-
       #   values$tag_variables[!(values$tag_variables %in% notes_variables)]
 
-      ### Bibliography table -----------------------------------------
-      if(all(values$bib_table_col %in%
-             names(values$d_mcdr_filtered))){
-        output$table <- renderDT(values$d_mcdr_filtered %>%
-                                    select(values$bib_table_col),
-                                 selection = list(mode ="single"),
-                                 options = list(dom = "t",
-                                                pageLength = 10000),
-                                 rownames = FALSE, server = FALSE)
-      }
 
       ### Show selected paper info -------------------------------------
       output$selected_year <- render_paper_info("Year:", "publication_year")
@@ -356,6 +383,8 @@ builder_server <- function(id) {
       values$bib_table_col <- c("first_author", "publication_year", "title")
       output$selected_extra <- NULL
     }
+    # trigger table update as column structure changed
+    values$table_trigger <- values$table_trigger + 1
   })
 
   ## Observe select filter fields  -------------------------------
@@ -398,12 +427,16 @@ builder_server <- function(id) {
     input$filter_var %>%
         map(\(x) filter_fun(x))
 
+    # trigger re-render on search/filter
+    values$table_trigger <- values$table_trigger + 1
   })
 
   ## Observe show all button  -------------------------
 
   observeEvent(input$show_all_db, {
     values$d_mcdr_filtered <-  values$d_mcdr_tagged
+    # trigger re-render
+    values$table_trigger <- values$table_trigger + 1
   })
 
   ## Observe unselect filters button ------------------------
@@ -458,6 +491,8 @@ builder_server <- function(id) {
       values$d_mcdr_filtered[values$d_mcdr_filtered$key == key,] <-
         values$d_mcdr_tagged[values$d_mcdr_tagged$key == key, ]
 
+      # trigger table update to show changes in bibliography columns (e.g. Extra)
+      values$table_trigger <- values$table_trigger + 1
     }
   }
 


### PR DESCRIPTION
- Refactor `R/builder_server.R` to maintain user-selected sort order after row selection or data updates.
- Enable `stateSave = TRUE` and `stateDuration = 0` to persist table state across interactions.
- Move scroll-centering logic to a JavaScript `select` event callback, ensuring the table centers the selected row smoothly without jumping during sorting.
- Use `server = FALSE` to eliminate "Invalid JSON response" errors and ensure consistent row mapping.
- Implement a manual `table_trigger` and `isolate()` to prevent unnecessary re-renders that reset widget state.
- Ensure bibliography updates are reflected in the table when edits are saved by incrementing the trigger in `save_last_row`.