### PR TITLE
Center bibliography table on selected row

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -161,6 +161,17 @@ builder_server <- function(id) {
           }
         }
       });
+      table.on('draw', function() {
+        var selected = table.rows({selected: true}).indexes();
+        if (selected.length > 0) {
+          var row = table.row(selected[selected.length - 1]).node();
+          if (row) {
+            setTimeout(function() {
+              row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            }, 100);
+          }
+        }
+      });
     "),
     options = list(dom = "t",
                    pageLength = 10000,


### PR DESCRIPTION
Modified R/builder_server.R to update the DataTables callback for the bibliography table. Added a 'draw' event listener to complement the 'select' listener, ensuring that the selected row is scrolled into view and centered even after table re-renders (e.g., due to filtering, sorting, or Shiny reactive updates). The logic uses 'selected.length - 1' to correctly target the most recently selected row.

---
*PR created automatically by Jules for task [9804293750573042825](https://jules.google.com/task/9804293750573042825) started by @pmcelhany*