### PR TITLE
Preserve bibliography table sort order in builder module

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -445,7 +445,8 @@ builder_server <- function(id) {
         map(\(x) filter_fun(x))
 
     # trigger re-render on search/filter
-    values$table_trigger <- values$table_trigger + 1
+    replaceData(dt_proxy, values$d_mcdr_filtered %>% select(all_of(values$bib_table_col)),
+                resetPaging = FALSE, rownames = FALSE)
   })
 
   ## Observe show all button  -------------------------
@@ -453,7 +454,8 @@ builder_server <- function(id) {
   observeEvent(input$show_all_db, {
     values$d_mcdr_filtered <-  values$d_mcdr_tagged
     # trigger re-render
-    values$table_trigger <- values$table_trigger + 1
+    replaceData(dt_proxy, values$d_mcdr_filtered %>% select(all_of(values$bib_table_col)),
+                resetPaging = FALSE, rownames = FALSE)
   })
 
   ## Observe unselect filters button ------------------------
@@ -507,7 +509,8 @@ builder_server <- function(id) {
         values$d_mcdr_tagged[values$d_mcdr_tagged$key == key, ]
 
       # trigger table update to show changes in bibliography columns (e.g. Extra)
-      values$table_trigger <- values$table_trigger + 1
+      replaceData(dt_proxy, values$d_mcdr_filtered %>% select(all_of(values$bib_table_col)),
+                  resetPaging = FALSE, rownames = FALSE)
     }
   }
 


### PR DESCRIPTION
This change modifies the builder module's server logic to preserve the bibliography table's sort order. By using `DT::replaceData` instead of a full re-render, the DataTable's client-side state is maintained during data updates. This was verified with a frontend test script that confirmed sort persistence after editing rows and filtering data. No other files were modified, and temporary test artifacts were removed before submission.

---
*PR created automatically by Jules for task [5490760425669876152](https://jules.google.com/task/5490760425669876152) started by @pmcelhany*