### PR TITLE
Retain Bibliography Table Sort Order

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -132,12 +132,27 @@ builder_server <- function(id) {
                            d_old_key_db = NULL, d_split_db = NULL,
                            tag_variables = NULL,
                            bib_table_col = c("first_author", "publication_year", "title"),
+                           bib_sort_column = "first_author",
+                           bib_sort_dir = "asc",
                            active_cat_tabs = character(0),
                            active_tag_ui = character(0),
                            table_trigger = 0)
 
     ## Proxy for the papers table ------------------------------
     dt_proxy <- DT::dataTableProxy("table")
+
+    # Capture user sort order
+    observeEvent(input$table_order, {
+      req(input$table_order)
+      order_info <- input$table_order[[1]]
+      col_idx <- order_info$column
+      dir <- order_info$dir
+
+      if (col_idx < length(values$bib_table_col)) {
+        values$bib_sort_column <- values$bib_table_col[col_idx + 1]
+        values$bib_sort_dir <- dir
+      }
+    })
 
     ### Bibliography table -----------------------------------------
     output$table <- renderDT({
@@ -146,23 +161,28 @@ builder_server <- function(id) {
       req(values$d_mcdr_filtered)
       req(all(values$bib_table_col %in% names(values$d_mcdr_filtered)))
 
-      isolate(values$d_mcdr_filtered) %>%
-        select(all_of(values$bib_table_col))
-    },
-    selection = list(mode = "single"),
-    callback = JS("
-      table.on('select', function() {
-        if (typeof table.centerRow === 'function') table.centerRow(true);
-      });
-    "),
-    options = list(dom = "t",
-                   pageLength = 10000,
-                   stateSave = TRUE,
-                   stateDuration = 0,
-                   order = list(),
-                   scrollY = "600px",
-                   scrollCollapse = TRUE,
-                   drawCallback = JS("function(settings) {
+      curr_sort_col <- isolate(values$bib_sort_column)
+      curr_sort_dir <- isolate(values$bib_sort_dir)
+      col_idx <- match(curr_sort_col, values$bib_table_col) - 1
+      if (is.na(col_idx)) col_idx <- 0
+
+      datatable(
+        isolate(values$d_mcdr_filtered) %>%
+          select(all_of(values$bib_table_col)),
+        selection = list(mode = "single"),
+        callback = JS("
+          table.on('select', function() {
+            if (typeof table.centerRow === 'function') table.centerRow(true);
+          });
+        "),
+        options = list(dom = "t",
+                       pageLength = 10000,
+                       stateSave = TRUE,
+                       stateDuration = 0,
+                       order = list(list(col_idx, curr_sort_dir)),
+                       scrollY = "600px",
+                       scrollCollapse = TRUE,
+                       drawCallback = JS("function(settings) {
                      var table = this.api();
                      table.centerRow = function(animate) {
                        var row = table.row('.selected').node();
@@ -186,7 +206,9 @@ builder_server <- function(id) {
                        table.centerRow(false);
                      }, 200);
                    }")),
-    rownames = FALSE, server = FALSE)
+        rownames = FALSE
+      )
+    }, server = FALSE)
 
   ## Render paper info function ----------------------------
   render_paper_info <- function(label, paper_var){


### PR DESCRIPTION
The bibliography table in the builder module was incorrectly reverting to its original sort order whenever a user selected a new row or saved edits. While `stateSave = TRUE` was present, it was insufficient for this specific Shiny/DT configuration.

The solution involves:
1.  **Capturing Sort State**: Adding a server-side observer that listens to `input$table_order` (the input DT provides when headers are clicked) and stores the current sort column (by name) and direction in `reactiveValues`.
2.  **Applying Sort State**: Refactoring the `renderDT` block to use `DT::datatable()`. This allows us to explicitly pass the `order` option, which is calculated based on the stored reactive values (using `isolate` to avoid unnecessary re-renders).
3.  **Preserving Behavior**: Ensuring that the custom JavaScript for row centering and other options like `pageLength` and `scrollY` remain intact.

This approach ensures the table's visual state is consistently maintained throughout the user session.

---
*PR created automatically by Jules for task [12436342417397934415](https://jules.google.com/task/12436342417397934415) started by @pmcelhany*