### PR TITLE
Fix summary table column display and reactive rendering

### DIFF
--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -102,16 +102,16 @@ viewer_server <- function(id) {
     ### newjs ------
     # function to get column order from summary table
     # code from https://stackoverflow.com/questions/59428159/in-r-shinyproxy-how-do-i-get-the-order-of-columns-from-a-dtdatatable-after-a
-    newjs <- 'table.on("column-reorder", function(e, settings, details){
-        var table = document.getElementById("summary_table");
+    newjs <- paste0('table.on("column-reorder", function(e, settings, details){
+        var table = document.getElementById("', ns("summary_table"), '");
         var thead = table.getElementsByTagName("thead");
         var ths = thead[0].getElementsByTagName("th");
         var tableFields = [];
         for (let i = 0; i < ths.length; i++) {
             tableFields[i] = ths[i].innerHTML;
         }
-        Shiny.onInputChange("colOrder", tableFields);
-    });'
+        Shiny.onInputChange("', ns("colOrder"), '", tableFields);
+    });')
 
 
     ## Reactive values --------------------------------------------
@@ -123,7 +123,6 @@ viewer_server <- function(id) {
                              table_trigger = 0)
 
     dt_proxy <- DT::dataTableProxy("table")
-    dt_summary_proxy <- DT::dataTableProxy("summary_table")
 
     # trigger table re-render when columns change
     observeEvent(input$show_extra, {
@@ -880,9 +879,8 @@ viewer_server <- function(id) {
     ## Summary table ---------------------------------------------
 
     ### Show summary table change -------------------
-    #observeEvent(input$show_summary_table,{
-    #observeEvent(c(input$summary_data),{
-    observeEvent(c(input$summary_var, input$summary_data, input$select_papers),{
+    output$summary_table <- renderDT({
+
       #### Use full data set or the filtered data set? -----------
       d <- NULL
       if(input$summary_data == "Full dataset"){
@@ -896,29 +894,22 @@ viewer_server <- function(id) {
            select(input$summary_var)
       }
 
-      output$summary_table <- renderDT({
-        req(d)
-        isolate(d)
-      },
-      selection = "none",
-      extensions = 'ColReorder',
-      callback = JS(newjs),
-      options = list(dom = "t",
-                     pageLength = 10000,
-                     stateSave = TRUE,
-                     stateDuration = 0,
-                     order = list(),
-                     columnDefs = list(list(visible = FALSE, targets = 0),
-                                       list(width = '200px', targets = "_all")),
-                     scrollX = TRUE,
-                     scrollY = TRUE,
-                     colReorder = TRUE),
-      rownames = FALSE, server = TRUE)
-
-      replaceData(dt_summary_proxy, d, resetPaging = FALSE,
-                  rownames = FALSE)
-
-    }, ignoreInit = TRUE)
+      req(d)
+      d
+    },
+    selection = "none",
+    extensions = 'ColReorder',
+    callback = JS(newjs),
+    options = list(dom = "t",
+                   pageLength = 10000,
+                   stateSave = TRUE,
+                   stateDuration = 0,
+                   order = list(),
+                   columnDefs = list(list(width = '200px', targets = "_all")),
+                   scrollX = TRUE,
+                   scrollY = TRUE,
+                   colReorder = TRUE),
+    rownames = FALSE, server = FALSE)
 
     ### Download summary csv ----------------------------
     output$download_summary <- downloadHandler(


### PR DESCRIPTION
The summary table on the “Summary table” tab was behaving oddly, failing to display all user-selected columns and often hiding the first selected column. 

This was caused by a combination of factors:
1. An observer-based rendering pattern that used `replaceData` (which can be unstable with dynamic columns).
2. A `columnDefs` rule that explicitly hid the first column (`targets = 0`), which erroneously targeted the first data column since `rownames` was set to `FALSE`.
3. Lack of proper module namespacing in the JavaScript `column-reorder` callback, preventing correct communication between the frontend and the Shiny server.

I refactored the rendering logic to follow Shiny best practices, switched to client-side processing (`server = FALSE`) for the summary table to improve stability, and fixed the namespacing and visibility issues.

---
*PR created automatically by Jules for task [14137485447331219762](https://jules.google.com/task/14137485447331219762) started by @pmcelhany*