### PR TITLE
Fix row selection and filter state persistence in bibliography table

### DIFF
--- a/R/builder_server.R
+++ b/R/builder_server.R
@@ -284,17 +284,27 @@ builder_server <- function(id) {
       # trigger update when data is initially loaded or filtered or when show_extra changes
       values$table_trigger
       req(values$d_mcdr_filtered)
-      req(all(values$bib_table_col %in% names(values$d_mcdr_filtered)))
+
+      d_filtered <- isolate(values$d_mcdr_filtered)
+      bib_cols <- isolate(values$bib_table_col)
+      req(all(bib_cols %in% names(d_filtered)))
 
       curr_sort_col <- isolate(values$bib_sort_column)
       curr_sort_dir <- isolate(values$bib_sort_dir)
-      col_idx <- match(curr_sort_col, values$bib_table_col) - 1
+      col_idx <- match(curr_sort_col, bib_cols) - 1
       if (is.na(col_idx)) col_idx <- 0
 
+      # Determine selected row index
+      sel_row <- NULL
+      last_key <- isolate(values$last_key)
+      if (!is.null(last_key) && "key" %in% names(d_filtered)) {
+        sel_row <- which(d_filtered$key == last_key)
+      }
+
       datatable(
-        isolate(values$d_mcdr_filtered) %>%
-          select(all_of(values$bib_table_col)),
-        selection = list(mode = "single"),
+        d_filtered %>%
+          select(all_of(bib_cols)),
+        selection = list(mode = "single", selected = sel_row),
         callback = JS(paste0("
           table.on('select', function() {
             if (typeof table.centerRow === 'function') table.centerRow(true);
@@ -566,14 +576,19 @@ builder_server <- function(id) {
 
     ### Render UI of filters -----------------------------
     output$filters  <- renderUI({
+      d_tagged <- isolate(values$d_mcdr_tagged)
       input$filter_var %>%
-          map(\(x) checkboxGroupInput(ns(paste("filter", x, sep = "_")),
-                                    paste("filter", x, sep = "_"),
-                                    unique(values$d_mcdr_tagged %>%
-                                              pull(x) %>%
-                                             replace_na("NA")) %>%
-                                      sort(),
-                                    inline = TRUE))
+        map(\(x) {
+          id <- paste("filter", x, sep = "_")
+          checkboxGroupInput(ns(id),
+                             id,
+                             unique(d_tagged %>%
+                                      pull(x) %>%
+                                      replace_na("NA")) %>%
+                               sort(),
+                             selected = isolate(input[[id]]),
+                             inline = TRUE)
+        })
     })
 
   })


### PR DESCRIPTION
This PR fixes a bug in the "Tag edits" tab of the builder module where filtering the bibliography table caused row selections to be dropped and filter checkboxes to be unchecked.

Key changes:
1. **Table Selection Persistence**: Modified the `renderDT` call for the bibliography table to store and restore the selected row index using the record's unique key. This ensures that when the table re-renders (e.g., after a tag update), the user's selection is maintained.
2. **Filter State Preservation**: Updated the dynamic UI generation for filter checkboxes to explicitly set their `selected` state to their current value before re-rendering. This prevents the checkboxes from resetting to an empty state.
3. **Reactivity Optimization**: Applied `isolate()` to data dependencies in both the table and filter UI rendering blocks to ensure they only update when explicitly triggered, improving stability and performance.

---
*PR created automatically by Jules for task [11803620526659266485](https://jules.google.com/task/11803620526659266485) started by @pmcelhany*