### PR TITLE
Fix navbar color bleed in viewer module

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -26,6 +26,11 @@ golem_add_external_resources <- function() {
     app_sys("app/www")
   )
 
+  add_resource_path(
+    "reports",
+    app_sys("report")
+  )
+
   tags$head(
     favicon(),
     bundle_resources(

--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -1009,9 +1009,12 @@ viewer_server <- function(id) {
       withProgress(message = "Rendering report", value = 0, {
         incProgress(1/4)
         render_quarto_fun("html")
-        output$report <- renderUI(includeHTML({
-          "report/lit_tag_report_template.html"
-        }))
+        output$report <- renderUI({
+          tags$iframe(
+            src = paste0("reports/lit_tag_report_template.html?t=", as.numeric(Sys.time())),
+            style = "width: 100%; height: 800px; border: none;"
+          )
+        })
         incProgress(4/4)
       })
     })

--- a/R/viewer_ui.R
+++ b/R/viewer_ui.R
@@ -230,7 +230,7 @@ viewer_ui <- function(id){
                              downloadButton(ns("download_report"), "Download report")
                 ),
                 mainPanel(width = 9,
-                          htmlOutput(ns("report")))
+                          htmlOutput(ns("report"), style = "width: 100%;"))
               )
     ),
     ## Help panel ------------------------


### PR DESCRIPTION
The color of the app's top navigation band was changing from white to blue after rendering a report in the lit-tag viewer. This was caused by CSS leakage from the rendered Quarto report (which contains its own Bootstrap styling) when it was injected into the app using `includeHTML()`.

To resolve this, I modified the application to display the report within an `iframe`. This ensures that the report's styles are isolated from the main application.

Key modifications:
- **`R/app_ui.R`**: Added `add_resource_path("reports", app_sys("report"))` to expose the directory where reports are generated, allowing them to be served via a URL.
- **`R/viewer_ui.R`**: Styled the `htmlOutput("report")` to ensure the iframe correctly occupies the available space.
- **`R/viewer_server.R`**: Replaced the `includeHTML()` call with `tags$iframe()`. A cache-busting query parameter (`?t=TIMESTAMP`) was added to the iframe's `src` to ensure it reloads the newly generated report each time.

Verified that the R code is syntactically correct. Frontend behavior was verified using a Playwright script to the extent possible (report generation itself requires a local `quarto` installation which was missing in the sandbox, but the UI structure change was confirmed).

---
*PR created automatically by Jules for task [4423376256377069192](https://jules.google.com/task/4423376256377069192) started by @pmcelhany*