### PR TITLE
Fix CSS leaks, report vertical sizing, and paper table container fill

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -26,6 +26,11 @@ golem_add_external_resources <- function() {
     app_sys("app/www")
   )
 
+  add_resource_path(
+    "reports",
+    app_sys("report")
+  )
+
   tags$head(
     favicon(),
     bundle_resources(

--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -146,12 +146,12 @@ viewer_server <- function(id) {
         select(all_of(table_vars()))
     },
     selection = "single",
+    fillContainer = TRUE,
     options = list(dom = "t",
                    pageLength = 10000,
                    stateSave = TRUE,
                    stateDuration = 0,
                    order = list(),
-                   scrollY = "600px",
                    scrollCollapse = TRUE,
                    drawCallback = JS("function(settings) {
                      var table = this.api();
@@ -1009,9 +1009,12 @@ viewer_server <- function(id) {
       withProgress(message = "Rendering report", value = 0, {
         incProgress(1/4)
         render_quarto_fun("html")
-        output$report <- renderUI(includeHTML({
-          "report/lit_tag_report_template.html"
-        }))
+        output$report <- renderUI({
+          tags$iframe(
+            src = paste0("reports/lit_tag_report_template.html?t=", as.numeric(Sys.time())),
+            style = "width: 100%; height: 100vh; border: none;"
+          )
+        })
         incProgress(4/4)
       })
     })

--- a/R/viewer_ui.R
+++ b/R/viewer_ui.R
@@ -61,10 +61,15 @@ viewer_ui <- function(id){
                 col_widths = c(4,4,4),
                 ### Left panel: table of papers ---------------------
                 card(card_header(h3("Paper table (filtered)")),
-                     checkboxInput(ns("show_extra"),
-                                   "Show \"extra\" field",
-                                   value = FALSE),
-                     DTOutput(ns('table'))),
+                     card_body(
+                       checkboxInput(ns("show_extra"),
+                                     "Show \"extra\" field",
+                                     value = FALSE),
+                       fill = FALSE
+                     ),
+                     card_body(
+                       DTOutput(ns('table'))
+                     )),
 
                 ### Center panel: search criteria ---------------------------
                 card(card_header(h3("Search criteria")),
@@ -230,7 +235,7 @@ viewer_ui <- function(id){
                              downloadButton(ns("download_report"), "Download report")
                 ),
                 mainPanel(width = 9,
-                          htmlOutput(ns("report")))
+                          htmlOutput(ns("report"), style = "width: 100%;"))
               )
     ),
     ## Help panel ------------------------


### PR DESCRIPTION
- Replaced includeHTML() with an isolated iframe for Quarto reports to prevent CSS leakage.
- Exposed the report directory as a Shiny resource path.
- Set report iframe height to 100vh for full-window vertical fill.
- Configured the filtered paper table to fill its card container by using fillContainer=TRUE and bslib card_body() structure.
- Added cache-busting to the report iframe.