### PR TITLE
Fix PDF report rendering error in viewer module

### DIFF
--- a/R/utils_quarto.R
+++ b/R/utils_quarto.R
@@ -1,0 +1,23 @@
+#' Escape LaTeX special characters
+#'
+#' @param t A character string or vector
+#'
+#' @return A character string or vector with LaTeX special characters escaped
+#' @noRd
+escape_latex <- function(t) {
+  if (is.null(t)) return(NULL)
+  # Use a very specific placeholder for backslashes to avoid collisions
+  placeholder <- "RESERVED_BACKSLASH_PLACEHOLDER_XYZ"
+  t <- gsub("\\", placeholder, t, fixed = TRUE)
+  t <- gsub("&", "\\&", t, fixed = TRUE)
+  t <- gsub("%", "\\%", t, fixed = TRUE)
+  t <- gsub("$", "\\$", t, fixed = TRUE)
+  t <- gsub("#", "\\#", t, fixed = TRUE)
+  t <- gsub("_", "\\_", t, fixed = TRUE)
+  t <- gsub("{", "\\{", t, fixed = TRUE)
+  t <- gsub("}", "\\}", t, fixed = TRUE)
+  t <- gsub("~", "\\textasciitilde{}", t, fixed = TRUE)
+  t <- gsub("^", "\\textasciicircum{}", t, fixed = TRUE)
+  t <- gsub(placeholder, "\\textbackslash{}", t, fixed = TRUE)
+  return(t)
+}

--- a/R/viewer_server.R
+++ b/R/viewer_server.R
@@ -940,6 +940,7 @@ viewer_server <- function(id) {
 
     ## Render quarto fun -----------
     render_quarto_fun <- function(report_type){
+
       d_report <- values$d_mcdr_tagged
       if(input$report_data == "Filtered dataset") {
         d_report <- values$d_mcdr_filtered
@@ -960,6 +961,11 @@ viewer_server <- function(id) {
 
       d_report <- d_report %>%
         replace(is.na(.), "NA")
+
+      if(report_type == "pdf"){
+        d_report <- d_report %>%
+          mutate(across(everything(), \(x) escape_latex(x)))
+      }
 
       categories <- values$categories %>%
          list_modify("notes" = rlang::zap())


### PR DESCRIPTION
Identified and fixed a PDF rendering crash caused by LaTeX special characters in the citation database. The reported "captions" error was confirmed to be a side-effect of how the R `quarto` package handles CLI errors containing braces. Data is now sanitized specifically for PDF output.

---
*PR created automatically by Jules for task [13170923505576994132](https://jules.google.com/task/13170923505576994132) started by @pmcelhany*